### PR TITLE
fixup: use memory space for Cabana class templates

### DIFF
--- a/src/ProblemManager.hpp
+++ b/src/ProblemManager.hpp
@@ -146,7 +146,7 @@ class ProblemManager
 
         // Get Local Grid and Local Mesh
         auto local_grid = *( _mesh.localGrid() );
-        auto local_mesh = Cabana::Grid::createLocalMesh<device_type>( local_grid );
+        auto local_mesh = Cabana::Grid::createLocalMesh<memory_space>( local_grid );
 
 	// Get State Arrays
         auto z = get( Cabana::Grid::Node(), Field::Position() );

--- a/src/SiloWriter.hpp
+++ b/src/SiloWriter.hpp
@@ -149,12 +149,12 @@ class SiloWriter
         // array that we copy data into and then get a mirror view of.
         Kokkos::View<typename pm_type::node_array::value_type***,
                      Kokkos::LayoutLeft,
-                     typename pm_type::node_array::device_type>
+                     typename pm_type::node_array::memory_space>
             w1Owned( "w1o", node_domain.extent( 0 ), node_domain.extent( 1 ),
                     1 );
         Kokkos::View<typename pm_type::node_array::value_type***,
                      Kokkos::LayoutLeft,
-                     typename pm_type::node_array::device_type>
+                     typename pm_type::node_array::memory_space>
             w2Owned( "w2o", node_domain.extent( 0 ), node_domain.extent( 1 ),
                     1 );
 

--- a/src/ZModel.hpp
+++ b/src/ZModel.hpp
@@ -189,7 +189,7 @@ class ZModel
         /* Construct the temporary arrays C1 and C2 */
         auto local_grid = _pm.mesh().localGrid();
         auto & global_grid = local_grid->globalGrid();
-        auto local_mesh = Cabana::Grid::createLocalMesh<device_type>( *local_grid );
+        auto local_mesh = Cabana::Grid::createLocalMesh<memory_space>( *local_grid );
         auto local_nodes = local_grid->indexSpace(Cabana::Grid::Own(), Cabana::Grid::Node(), Cabana::Grid::Local());
 
         /* Get the views we'll be computing with in parallel loops */


### PR DESCRIPTION
Making similar changes in https://github.com/ECP-copa/ExaMPM/pull/58

See https://github.com/ECP-copa/Cabana/pull/585