### PR TITLE
fixup: use ZModel class exec space for FFT

### DIFF
--- a/src/ZModel.hpp
+++ b/src/ZModel.hpp
@@ -128,7 +128,7 @@ class ZModel
         params.setAllToAll(true);
         params.setPencils(true);
         params.setReorder(false);
-        _fft = Cabana::Grid::Experimental::createHeffteFastFourierTransform<double, memory_space>(*node_double_layout, params);
+        _fft = Cabana::Grid::Experimental::createHeffteFastFourierTransform<double, memory_space>(exec_space{}, *node_double_layout, params);
     }
 
     double computeMinTimestep(double atwood, double g)


### PR DESCRIPTION
Previously used create function overload used the default execution space, which conflicted when multiple host backends were enabled 