### PR TITLE
Bring develop up to date with main

### DIFF
--- a/examples/rocketrig.cpp
+++ b/examples/rocketrig.cpp
@@ -53,7 +53,7 @@
 
 using namespace Beatnik;
 
-static char* shortargs = (char*)"n:B:t:d:x:F:o:c:H:I:b:g:a:T:m:v:p:i:w:O:S:M:e:h:";
+static char* shortargs = (char*)"n:B:t:d:x:F:o:c:H:I:b:g:a:T:m:v:p:i:w:O:S:M:e:h";
 
 static option longargs[] = {
     // Basic simulation parameters
@@ -539,6 +539,8 @@ int parseInput( const int rank, const int argc, char** argv, ClArgs& cl )
             break;
         case 'h':
             help( rank, argv[0] );
+            Kokkos::finalize(); 
+            MPI_Finalize(); 
             exit( 0 );
             break;
         case 't':

--- a/src/BRSolverBase.hpp
+++ b/src/BRSolverBase.hpp
@@ -14,23 +14,6 @@
 
 #include <Beatnik_Config.hpp>
 
-#include <Cabana_Grid.hpp>
-
-#include <BoundaryCondition.hpp>
-#include <SurfaceMesh.hpp>
-#include <SpatialMesh.hpp>
-#include <ProblemManager.hpp>
-#include <SiloWriter.hpp>
-#include <TimeIntegrator.hpp>
-
-#include <ZModel.hpp>
-
-#include <Kokkos_Core.hpp>
-#include <memory>
-#include <string>
-
-#include <mpi.h>
-
 namespace Beatnik
 {
 
@@ -41,8 +24,7 @@ template <class ExecutionSpace, class MemorySpace, class Params>
 class BRSolverBase
 {
   public:
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
-    using node_view = Kokkos::View<double***, device_type>;
+    using node_view = Kokkos::View<double***, MemorySpace>;
     virtual ~BRSolverBase() = default;
     virtual void computeInterfaceVelocity(node_view zdot, node_view z, node_view o) const = 0;
 };

--- a/src/CutoffBRSolver.hpp
+++ b/src/CutoffBRSolver.hpp
@@ -35,6 +35,7 @@
 #include <memory>
 
 #include <BRSolverBase.hpp>
+#include <SpatialMesh.hpp>
 #include <HaloComm.hpp>
 #include <SurfaceMesh.hpp>
 #include <ProblemManager.hpp>
@@ -58,14 +59,13 @@ class CutoffBRSolver : public BRSolverBase<ExecutionSpace, MemorySpace, Params>
     using memory_space = MemorySpace;
     using pm_type = ProblemManager<ExecutionSpace, MemorySpace>;
     using spatial_mesh_type = SpatialMesh<ExecutionSpace, MemorySpace>;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     using mesh_type = Cabana::Grid::UniformMesh<double, 2>;
     
     using Node = Cabana::Grid::Node;
     using l2g_type = Cabana::Grid::IndexConversion::L2G<mesh_type, Node>;
     using node_array = typename pm_type::node_array;
     //using node_view = typename pm_type::node_view;
-    using node_view = Kokkos::View<double***, device_type>;
+    using node_view = Kokkos::View<double***, memory_space>;
 
     using halo_type = Cabana::Grid::Halo<MemorySpace>;
 
@@ -81,7 +81,7 @@ class CutoffBRSolver : public BRSolverBase<ExecutionSpace, MemorySpace, Params>
                                               >;
     // XXX Change the final parameter of particle_array_type, vector type, to
     // be aligned with the machine we are using
-    using particle_array_type = Cabana::AoSoA<particle_node, device_type, 4>;
+    using particle_array_type = Cabana::AoSoA<particle_node, memory_space, 4>;
 
     // XXX - Get these from SpatialMesh class?
     using spatial_mesh_layout = Cabana::Grid::UniformMesh<double, 3>;
@@ -319,7 +319,7 @@ class CutoffBRSolver : public BRSolverBase<ExecutionSpace, MemorySpace, Params>
         /* See https://kokkos.org/kokkos-core-wiki/API/core/view/deep_copy.html
          * "How to get layout incompatiable views copied"
          */
-        Kokkos::View<int*[4], device_type> boundary_topology_device("boundary_topology_device", _comm_size+1);
+        Kokkos::View<int*[4], memory_space> boundary_topology_device("boundary_topology_device", _comm_size+1);
         auto hv_tmp = Kokkos::create_mirror_view(boundary_topology_device);
         Kokkos::deep_copy(hv_tmp, boundary_topology);
         Kokkos::deep_copy(boundary_topology_device, hv_tmp);

--- a/src/ExactBRSolver.hpp
+++ b/src/ExactBRSolver.hpp
@@ -58,15 +58,13 @@ class ExactBRSolver : public BRSolverBase<ExecutionSpace, MemorySpace, Params>
     using exec_space = ExecutionSpace;
     using memory_space = MemorySpace;
     using pm_type = ProblemManager<ExecutionSpace, MemorySpace>;
-    using spatial_mesh_type = SpatialMesh<ExecutionSpace, MemorySpace>;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     using mesh_type = Cabana::Grid::UniformMesh<double, 2>;
     
     using Node = Cabana::Grid::Node;
     using l2g_type = Cabana::Grid::IndexConversion::L2G<mesh_type, Node>;
     using node_array = typename pm_type::node_array;
     //using node_view = typename pm_type::node_view;
-    using node_view = Kokkos::View<double***, device_type>;
+    using node_view = Kokkos::View<double***, memory_space>;
 
     using halo_type = Cabana::Grid::Halo<MemorySpace>;
 

--- a/src/ProblemManager.hpp
+++ b/src/ProblemManager.hpp
@@ -78,7 +78,6 @@ class ProblemManager
   public:
     using exec_space = ExecutionSpace;
     using mem_space = MemorySpace;
-    using device_type = Kokkos::Device<exec_space, mem_space>;
 
     using Node = Cabana::Grid::Node;
 

--- a/src/SiloWriter.hpp
+++ b/src/SiloWriter.hpp
@@ -44,7 +44,6 @@ class SiloWriter
 {
   public:
     using pm_type = ProblemManager<ExecutionSpace, MemorySpace>;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     /**
      * Constructor
      * Create new SiloWriter

--- a/src/Solver.hpp
+++ b/src/Solver.hpp
@@ -104,7 +104,6 @@ template <class ExecutionSpace, class MemorySpace, class ModelOrder>
 class Solver : public SolverBase
 {
   public:
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     using node_array =
         Cabana::Grid::Array<double, Cabana::Grid::Node, Cabana::Grid::UniformMesh<double, 2>, MemorySpace>;
     using pm_type = ProblemManager<ExecutionSpace, MemorySpace>;
@@ -138,7 +137,7 @@ class Solver : public SolverBase
         // handle state
         _surface_mesh = std::make_unique<SurfaceMesh<ExecutionSpace, MemorySpace>>(
             _params.global_bounding_box, num_nodes, _params.periodic, partitioner,
-	    _halo_min, comm );
+	        _halo_min, comm );
 
         // XXX - Check that our timestep is small enough to handle the mesh size,
         // atwood number and acceleration, and solution method. 
@@ -322,7 +321,7 @@ createSolver( const std::string& device, MPI_Comm comm,
     {
 #ifdef KOKKOS_ENABLE_HIP
         return std::make_shared<Beatnik::Solver<Kokkos::HIP, 
-            Kokkos::Experimental::HIPSpace, ModelOrder>>(
+            Kokkos::HIPSpace, ModelOrder>>(
                 comm, global_num_cell, partitioner, atwood, g, 
                 create_functor, bc, mu, epsilon, delta_t, params);
 #else

--- a/src/SpatialMesh.hpp
+++ b/src/SpatialMesh.hpp
@@ -34,7 +34,6 @@ class SpatialMesh
 {
   public:
     using memory_space = MemorySpace;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     using mesh_type = Cabana::Grid::UniformMesh<double, 3>;
     using local_grid_type = Cabana::Grid::LocalGrid<mesh_type>;
     using global_particle_comm_type = Cabana::Grid::GlobalParticleComm<memory_space, local_grid_type>;

--- a/src/SurfaceMesh.hpp
+++ b/src/SurfaceMesh.hpp
@@ -34,7 +34,6 @@ class SurfaceMesh
 {
   public:
     using memory_space = MemorySpace;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     using mesh_type = Cabana::Grid::UniformMesh<double, 2>;
 
     // Construct a mesh.

--- a/src/TimeIntegrator.hpp
+++ b/src/TimeIntegrator.hpp
@@ -30,7 +30,6 @@ class TimeIntegrator
 {
     using exec_space = ExecutionSpace;
     using mem_space = MemorySpace;
-    using device_type = Kokkos::Device<exec_space, mem_space>;
     using node_array =
         Cabana::Grid::Array<double, Cabana::Grid::Node, Cabana::Grid::UniformMesh<double, 2>,
                       mem_space>;

--- a/src/ZModel.hpp
+++ b/src/ZModel.hpp
@@ -67,7 +67,6 @@ class ZModel
     using memory_space = MemorySpace;
     using pm_type = ProblemManager<ExecutionSpace, MemorySpace>;
     using br_solver_type = BRSolverBase<ExecutionSpace, MemorySpace, Params>;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
     using mesh_type = Cabana::Grid::UniformMesh<double, 2>; 
 
     using Node = Cabana::Grid::Node;

--- a/tests/tstCutoffBRSolver.hpp
+++ b/tests/tstCutoffBRSolver.hpp
@@ -20,7 +20,6 @@ class CutoffBRSolverTest : public TestingBase<T>
 {
     using ExecutionSpace = typename T::ExecutionSpace;
     using MemorySpace = typename T::MemorySpace;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     using mesh_type = Cabana::Grid::UniformMesh<double, 2>;
     using local_grid_type = Cabana::Grid::LocalGrid<mesh_type>;
@@ -43,7 +42,7 @@ class CutoffBRSolverTest : public TestingBase<T>
                                               int,       // Owning rank in 3D space                         7
                                               int        // Point ID in 3D                                  8
                                               >;
-    using particle_array_type = Cabana::AoSoA<particle_node, device_type, 4>;
+    using particle_array_type = Cabana::AoSoA<particle_node, MemorySpace, 4>;
    
 
   protected:
@@ -90,7 +89,7 @@ class CutoffBRSolverTest : public TestingBase<T>
         particle_array_type particle_array_;
 
         int dim = this->comm_size_ + this->haloWidth_*2;
-        Kokkos::View<double**[2], device_type> omega_("omega_", dim, dim);
+        Kokkos::View<double**[2], MemorySpace> omega_("omega_", dim, dim);
         this->p_br_cutoff_->initializeParticles(particle_array_, z, omega_);
         this->p_br_cutoff_->migrateParticlesTo3D(particle_array_);
         int owned_3D_count = particle_array_.size();

--- a/tests/tstExactBRSolver.hpp
+++ b/tests/tstExactBRSolver.hpp
@@ -51,7 +51,6 @@ class ExactBRSolverTest : public TestingBase<T>
 {
     using ExecutionSpace = typename T::ExecutionSpace;
     using MemorySpace = typename T::MemorySpace;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     using surface_mesh_type = Beatnik::SurfaceMesh<ExecutionSpace,MemorySpace>;
     using pm_type = Beatnik::ProblemManager<ExecutionSpace, MemorySpace>;
@@ -277,7 +276,7 @@ class ExactBRSolverTest : public TestingBase<T>
         /* Get an atomic view of the interface velocity, since each k/l point
          * is going to be updating it in parallel */
         Kokkos::View<double ***,
-             typename node_view::device_type,
+             typename node_view::memory_space,
              Kokkos::MemoryTraits<Kokkos::Atomic>> atomic_zdot = zdot_;
     
         /* Zero out all of the i/j points */

--- a/tests/tstZModel.hpp
+++ b/tests/tstZModel.hpp
@@ -20,7 +20,6 @@ class ZModelTest : public TestingBase<T>
 {
     using ExecutionSpace = typename T::ExecutionSpace;
     using MemorySpace = typename T::MemorySpace;
-    using device_type = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     using node_array =
         Cabana::Grid::Array<double, Cabana::Grid::Node, Cabana::Grid::UniformMesh<double, 2>,


### PR DESCRIPTION
The fixes that removed `device_type` are still present in develop because the edits were merged into main.